### PR TITLE
support spm

### DIFF
--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,11 @@
+/node_modules/
+/tmp
+/tasks
+/test
+/vendor
+/.jshintrc
+/.npmignore
+/.travis.yml
+/Gruntfile.js
+/component.json
+/index.html

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "futures"
   ],
   "author": "Yehuda Katz, Tom Dale, Stefan Penner and contributors (Conversion to ES6 API by Jake Archibald)",
-  "license": "MIT"
+  "license": "MIT",
+  "spm": {
+    "main": "dist/es6-promise.js"
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/snabbt.js

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of snabbt.js in spmjs, I can add it for your account after signing in http://spmjs.io.

spmjs/spm#781