### PR TITLE
not the right path, but a spike to evaluate what i actually need to do

### DIFF
--- a/lib/es6-promise/-internal.js
+++ b/lib/es6-promise/-internal.js
@@ -18,7 +18,7 @@ function selfFullfillment() {
 }
 
 function cannotReturnOwn() {
-  return new TypeError('A promises callback cannot return that same promise.')
+  return new TypeError('A promises callback cannot return that same promise.');
 }
 
 function getThen(promise) {

--- a/lib/es6-promise/enumerator.js
+++ b/lib/es6-promise/enumerator.js
@@ -27,9 +27,9 @@ export function makeSettledResult(state, position, value) {
   }
 }
 
-function Enumerator(Constructor, input, abortOnReject, label) {
+function Enumerator(Constructor, input, abortOnReject) {
   this._instanceConstructor = Constructor;
-  this.promise = new Constructor(noop, label);
+  this.promise = new Constructor(noop);
   this._abortOnReject = abortOnReject;
 
   if (this._validateInput(input)) {
@@ -116,7 +116,6 @@ Enumerator.prototype._makeResult = function(state, i, value) {
 
 Enumerator.prototype._willSettleAt = function(promise, i) {
   var enumerator = this;
-
   subscribe(promise, undefined, function(value) {
     enumerator._settledAt(FULFILLED, i, value);
   }, function(reason) {

--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -7,9 +7,9 @@ export default function polyfill() {
 
   if (P && Object.prototype.toString.call(Promise.resolve()) === '[object Promise]' && !Promise.cast) {
     try {
-      var K = function (r) { P.call(this, r); }
+      var K = function (r) { P.call(this, r); };
       K.prototype = Object.create(P.prototype);
-      new K(function() { })
+      new K(function() { });
       return;
     } catch(e) {
       // Promise is not subclassable

--- a/lib/es6-promise/promise.js
+++ b/lib/es6-promise/promise.js
@@ -5,11 +5,7 @@ import {
 
 import {
   noop,
-  subscribe,
-  initializePromise,
-  invokeCallback,
-  FULFILLED,
-  REJECTED
+  initializePromise
 } from './-internal';
 
 import asap from './asap';
@@ -18,6 +14,8 @@ import all from './promise/all';
 import race from './promise/race';
 import Resolve from './promise/resolve';
 import Reject from './promise/reject';
+import Then from './promise/then';
+import Catch from './promise/catch';
 
 var counter = 0;
 
@@ -353,28 +351,8 @@ Promise.prototype = {
   Useful for tooling.
   @return {Promise}
 */
-  then: function(onFulfillment, onRejection) {
-    var parent = this;
-    var state = parent._state;
-
-    if (state === FULFILLED && !onFulfillment || state === REJECTED && !onRejection) {
-      return this;
-    }
-
-    var child = new this.constructor(noop);
-    var result = parent._result;
-
-    if (state) {
-      var callback = arguments[state - 1];
-      asap(function(){
-        invokeCallback(state, child, callback, result);
-      });
-    } else {
-      subscribe(parent, child, onFulfillment, onRejection);
-    }
-
-    return child;
-  },
+  then: Then,
+ 
 
 /**
   `catch` is simply sugar for `then(undefined, onRejection)` which makes it the same
@@ -403,7 +381,5 @@ Promise.prototype = {
   Useful for tooling.
   @return {Promise}
 */
-  'catch': function(onRejection) {
-    return this.then(null, onRejection);
-  }
+  'catch': Catch
 };

--- a/lib/es6-promise/promise/all.js
+++ b/lib/es6-promise/promise/all.js
@@ -41,12 +41,11 @@ import Enumerator from '../enumerator';
   @method all
   @static
   @param {Array} entries array of promises
-  @param {String} label optional string for labeling the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all `promises` have been
   fulfilled, or rejected if any of them become rejected.
   @static
 */
-export default function all(entries, label) {
-  return new Enumerator(this, entries, true /* abort on reject */, label).promise;
+export default function all(entries) {
+  return this.all === all ? new Enumerator(this, entries, true /* abort on reject */).promise : this.all(entries);
 }

--- a/lib/es6-promise/promise/catch.js
+++ b/lib/es6-promise/promise/catch.js
@@ -1,0 +1,3 @@
+export default function Catch(onRejection) {
+  return this.then(undefined, onRejection);
+}

--- a/lib/es6-promise/promise/race.js
+++ b/lib/es6-promise/promise/race.js
@@ -1,10 +1,10 @@
 import {
   isArray
 } from "../utils";
-
+import resolve from './resolve';
 import {
   noop,
-  resolve,
+  resolve as resolveInternal,
   reject,
   subscribe,
   PENDING
@@ -71,16 +71,13 @@ import {
   @method race
   @static
   @param {Array} promises array of promises to observe
-  @param {String} label optional string for describing the promise returned.
   Useful for tooling.
   @return {Promise} a promise which settles in the same way as the first passed
   promise to settle.
 */
-export default function race(entries, label) {
-  /*jshint validthis:true */
-  var Constructor = this;
 
-  var promise = new Constructor(noop, label);
+function internalRace(Constructor, entries) {
+  var promise = new Constructor(noop);
 
   if (!isArray(entries)) {
     reject(promise, new TypeError('You must pass an array to race.'));
@@ -90,7 +87,7 @@ export default function race(entries, label) {
   var length = entries.length;
 
   function onFulfillment(value) {
-    resolve(promise, value);
+    resolveInternal(promise, value);
   }
 
   function onRejection(reason) {
@@ -102,4 +99,8 @@ export default function race(entries, label) {
   }
 
   return promise;
+}
+
+export default function race(entries) {
+  return this.race === race ? internalRace(this, entries) : this.race(entries);
 }

--- a/lib/es6-promise/promise/reject.js
+++ b/lib/es6-promise/promise/reject.js
@@ -34,14 +34,15 @@ import {
   @method reject
   @static
   @param {Any} reason value that the returned promise will be rejected with.
-  @param {String} label optional string for identifying the returned promise.
-  Useful for tooling.
   @return {Promise} a promise rejected with the given `reason`.
 */
-export default function reject(reason, label) {
+export default function reject(reason) {
   /*jshint validthis:true */
+  if (this.reject !== reject) { return this.reject(reason); }
+
   var Constructor = this;
-  var promise = new Constructor(noop, label);
+  var promise = new Constructor(noop);
   _reject(promise, reason);
+
   return promise;
 }

--- a/lib/es6-promise/promise/resolve.js
+++ b/lib/es6-promise/promise/resolve.js
@@ -30,20 +30,30 @@ import {
   @method resolve
   @static
   @param {Any} value value that the returned promise will be resolved with
-  @param {String} label optional string for identifying the returned promise.
-  Useful for tooling.
   @return {Promise} a promise that will become fulfilled with the given
   `value`
 */
-export default function resolve(object, label) {
+export default function resolve(object) {
   /*jshint validthis:true */
   var Constructor = this;
 
-  if (object && typeof object === 'object' && object.constructor === Constructor) {
+  if (object &&
+      typeof object === 'object' &&
+      object.constructor === Constructor) {
     return object;
   }
 
-  var promise = new Constructor(noop, label);
-  _resolve(promise, object);
-  return promise;
+  if (this.resolve !== resolve) {
+    return slowResolve(Constructor, object);
+  } else {
+    var promise = new Constructor(noop);
+    _resolve(promise, object);
+    return promise;
+  }
+}
+
+function slowResolve(Constructor, object) {
+  return new Constructor(function(resolve) {
+    resolve(object);
+  });
 }

--- a/lib/es6-promise/promise/then.js
+++ b/lib/es6-promise/promise/then.js
@@ -1,0 +1,34 @@
+import {
+  noop,
+  subscribe,
+  invokeCallback,
+  FULFILLED,
+  REJECTED
+} from '../-internal';
+
+import asap from '../asap';
+
+export default function Then(onFulfillment, onRejection) {
+  if (this.then !== Then) { return this.then.apply(this, arguments); }
+
+  var parent = this;
+  var state = parent._state;
+
+  if (state === FULFILLED && !onFulfillment || state === REJECTED && !onRejection) {
+    return this;
+  }
+
+  var child = new this.constructor(noop);
+  var result = parent._result;
+
+  if (state) {
+    var callback = arguments[state - 1];
+    asap(function(){
+      invokeCallback(state, child, callback, result);
+    });
+  } else {
+    subscribe(parent, child, onFulfillment, onRejection);
+  }
+
+  return child;
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "minimatch": "^2.0.1",
     "mocha": "^1.20.1",
     "promises-aplus-tests-phantom": "^2.1.0-revise",
-    "release-it": "0.0.10"
+    "release-it": "0.0.10",
   },
   "scripts": {
     "build": "ember build",

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -998,3 +998,70 @@ describe("Thenables should not be able to run code during assimilation", functio
         assert.strictEqual(thenCalled, false);
     });
 });
+
+describe('hostile this', function() {
+  it('race', function(done) {
+    var BlueBirdPromise = require('bluebird');
+
+    Promise.race.call(BlueBirdPromise, [3]).then(function(a) {
+      assert.equal(a, 3);
+      done();
+    }, done);
+  });
+
+  it('resolve', function(done) {
+    var BlueBirdPromise = require('bluebird');
+
+    Promise.resolve.call(BlueBirdPromise, 3).then(function(a) {
+      assert.equal(a, 3);
+      done();
+    }, done);
+  });
+
+  it('reject', function(done) {
+    var BlueBirdPromise = require('bluebird');
+
+    Promise.reject.call(BlueBirdPromise, 3).then(undefined, function(reason) {
+      assert.equal(reason, 3);
+      done();
+    }, done);
+  });
+
+  it('all', function(done) {
+    var BlueBirdPromise = require('bluebird');
+    var slow = new BlueBirdPromise(function(resolve) {
+      setTimeout(function() { 
+        resolve('slow');
+      }, 100);
+    });
+
+    var own = new Promise(function(resolve) {
+      setTimeout(function() { 
+        resolve('own');
+      }, 100);
+    });
+
+    Promise.all.call(BlueBirdPromise, [3, slow, own]).then(function(value){
+      assert.equal(value[0], 3);
+      assert.equal(value[1], 'slow');
+      assert.equal(value[2], 'own');
+      done();
+    }, done);
+  });
+
+  it('then fulfillemtn', function(done) {
+    var BlueBirdPromise = require('bluebird');
+    Promise.prototype.then.call(BlueBirdPromise.resolve(1), function(value) {
+      assert.equal(value, 1);
+      done();
+    });
+  });
+
+  it('then rejection', function(done) {
+    var BlueBirdPromise = require('bluebird');
+    Promise.prototype.then.call(BlueBirdPromise.reject(1), undefined, function(reason) {
+      assert.equal(reason, 1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
related to: #77 

- [ ] don't just redirect to the `this`'s implementation, rather improve internal algorithms to only short-circuit if the method that is emulated has not yet been tampered with.

features that must detect tampering
- [ ] resolverless constructor
- [ ] external fulfillment
- [ ] external rejection
- [ ] external subscription

- [ ] push this back upstream to RSVP
- [ ] monitor performance suite

I suspect doing this correctly, will allow us to speed up the `Promise.all([obj])` scenario, as `then` will need to be plucked up earlier.

Unfortunately i don't have much time this weekend, hopefully i can finish up soon.