### PR TITLE
Support of polyfill on non-browser non-node.js environments

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -2,7 +2,7 @@
 import Promise from './promise';
 
 export default function polyfill() {
-  var local = (typeof global !== 'undefined') ? global : self;
+  var local = Function('return this;')();
   var P = local.Promise;
 
   if (P && Object.prototype.toString.call(Promise.resolve()) === '[object Promise]' && !Promise.cast) {


### PR DESCRIPTION
Hi, thanks for the great library.

I always prefer using this lib through polyfilled style, but I found that in some environments, such as titanium mobile, the current polyfill doesn't work.
After searching a bit on stackoverflow I found a generic way to access the global object, then I suggest this change.

see http://stackoverflow.com/a/3277192/1185492

Thanks,