### PR TITLE
Add support of polyfill() for some more environments

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -2,7 +2,20 @@
 import Promise from './promise';
 
 export default function polyfill() {
-  var local = (typeof global !== 'undefined') ? global : self;
+  var local;
+
+  if (typeof global !== 'undefined') {
+      local = global;
+  } else if (typeof self !== 'undefined') {
+      local = self;
+  } else {
+      try {
+          local = Function('return this')();
+      } catch (e) {
+          throw new Error('polyfill failed because global object is unavailable in this environment');
+      }
+  }
+
   var P = local.Promise;
 
   if (P && Object.prototype.toString.call(Promise.resolve()) === '[object Promise]' && !Promise.cast) {


### PR DESCRIPTION
This is improved version of #80.

This changes nothing when the environment is browser or node.js, and makes polyfill work in the environments in which global object is unnamed and Function constructor is available, such as Titanium Mobile or rhino. This also makes polyfill throw when the envrionment isn't browser nor node.js and Function constructor is unavailable because of CSP restriction. (I believe this makes sense.)

Thanks,