### PR TITLE
update polyfill with better native ES6 Promise test

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -18,8 +18,22 @@ export default function polyfill() {
 
   var P = local.Promise;
 
-  if (P && Object.prototype.toString.call(P.resolve()) === '[object Promise]' && !P.cast) {
-    return;
+
+  var nativeES6PromiseSupported =
+      P &&
+      // Some of these methods are missing from  Firefox/Chrome experimental implementations
+      'resolve' in P && 'reject' in P && 'all' in P && 'race' in P &&
+      //deprecated API
+      !('cast' in P) && !('from' in P ) &&
+      // Older version of the spec had a resolver object as the arg rather than a function
+      (function(){
+          var resolve;
+          new P(function(r){ resolve = r; });
+          return typeof resolve === 'function';
+      })();
+
+  if (nativeES6PromiseSupported){
+      return;
   }
 
   local.Promise = Promise;


### PR DESCRIPTION
```
Object.prototype.toString.call(Promise.resolve()) === '[object Promise]'   
```
not works in Chrome 