### PR TITLE
Follow thenable state not own state

### DIFF
--- a/lib/es6-promise/-internal.js
+++ b/lib/es6-promise/-internal.js
@@ -66,7 +66,7 @@ function handleForeignThenable(promise, thenable, then) {
 function handleOwnThenable(promise, thenable) {
   if (thenable._state === FULFILLED) {
     fulfill(promise, thenable._result);
-  } else if (promise._state === REJECTED) {
+  } else if (thenable._state === REJECTED) {
     reject(promise, thenable._result);
   } else {
     subscribe(thenable, undefined, function(value) {


### PR DESCRIPTION
fix #101 

This is only syncing a commit from [rsvp](https://github.com/tildeio/rsvp.js/pull/333), credits to @teddyzeenny for the original changes