### PR TITLE
ascii character for apostrophe (makes sourcemaps happier)

### DIFF
--- a/lib/es6-promise/promise.js
+++ b/lib/es6-promise/promise.js
@@ -32,7 +32,7 @@ export default Promise;
 /**
   Promise objects represent the eventual result of an asynchronous operation. The
   primary way of interacting with a promise is through its `then` method, which
-  registers callbacks to receive either a promise’s eventual value or the reason
+  registers callbacks to receive either a promise's eventual value or the reason
   why the promise cannot be fulfilled.
 
   Terminology


### PR DESCRIPTION
For context:

-https://github.com/thlorenz/exorcist/issues/17
-https://github.com/freedomjs/freedom/issues/276

Really one should be allowed to use unicode apostrophes in source code if they want, but since there's no harm sticking to ascii and it smoothes out build processes I decided to create a pull request for your consideration. Thanks!