### PR TITLE
Prevents polyfill by default in cases that support module.exports.

### DIFF
--- a/lib/es6-promise.umd.js
+++ b/lib/es6-promise.umd.js
@@ -11,6 +11,7 @@ if (typeof define === 'function' && define['amd']) {
   define(function() { return ES6Promise; });
 } else if (typeof module !== 'undefined' && module['exports']) {
   module['exports'] = ES6Promise;
+  return;
 } else if (typeof this !== 'undefined') {
   this['ES6Promise'] = ES6Promise;
 }


### PR DESCRIPTION
Generally within systems that support `module.exports` such as Node, it's a bad idea in NPM packages to ever alter the global state. Thus, it seems in Node we shouldn't execute the Polyfill by default.

From the docs itself it says 

```js
var Promise = require('es6-promise').Promise;
```

While if you did
```js
var fake = require('es6-promise').Promise;
console.log(Promise === undefined); // false, What, where did this come from? I set it to fake.
```

You would still end up with Promise defined, that to me seems incorrect. I've altered the `module.exports` portion of the UMD to no longer leak the promise and execute the polyfill.