### PR TITLE
Mangle and compress the minified version

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -41,7 +41,7 @@ var dist = es6Promise;
 
 env('production', function() {
   dist = merge([
-    rename(uglify(dist), '.js', '.min.js'),
+    rename(uglify(dist, { mangle: true, compress: true }), '.js', '.min.js'),
     dist
   ]);
 });


### PR DESCRIPTION
This closes #142 

The default values for `mangle` and `compress` options seem to be `false`. (The readme of broccoli-uglify-js is confusing and they have a issue for that ( https://github.com/joliss/broccoli-uglify-js/pull/9 ) ).

This setting reduces the build size from 17,952 bytes to 6,408 bytes.

Thanks,