### PR TITLE
Use container based infrastructure on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: node_js
 node_js:
 - '0.10'
+
+sudo: false
+
 after_success:
 - "./bin/publish_to_s3.js"
 before_install:


### PR DESCRIPTION
This change enables to use the container based infrastructure on travis-ci and must speed up the build.

http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Thanks,