### PR TITLE
Fix Object.prototype.toString without Symbol.toStringTag support

### DIFF
--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -16,9 +16,16 @@ export default function polyfill() {
       }
   }
 
-  var P = local.Promise;
+  var P = local.Promise,
+      promiseName = Object.prototype.toString.call(P.resolve());
 
-  if (P && Object.prototype.toString.call(P.resolve()) === '[object Promise]' && !P.cast) {
+  if ( P && !P.cast &&
+      (
+        promiseName === '[object Promise]' && local.Symbol
+        ||
+        promiseName === '[object Object]'
+      )
+  ) {
     return;
   }
 

--- a/lib/es6-promise/polyfill.js
+++ b/lib/es6-promise/polyfill.js
@@ -17,9 +17,9 @@ export default function polyfill() {
   }
 
   var P = local.Promise,
-      promiseName = Object.prototype.toString.call(P.resolve());
+      promiseName = P && P.resolve ? Object.prototype.toString.call(P.resolve()) : null;
 
-  if ( P && !P.cast &&
+  if ( P && !P.cast && promiseName &&
       (
         promiseName === '[object Promise]' && local.Symbol
         ||


### PR DESCRIPTION
Browsers don't implement Promise[Symbol.species] [yet](https://kangax.github.io/compat-table/es6/#test-Promise). 

So if  execute `Object.prototype.toString.call(Promise.resolve()) ` in FF Nightly, Chrome, Chrome Canary results will be the next:

* Firefox Nightly 44 - [object Promise]
* Chrome Canary 48 (with flag) - [object Promise] 
* Chrome Canary 48 (without flag) - [object Object] 
* Chrome 46 - [object Object]

So I must use polyfill in Chrome 46, but it have native implementation.

This is the issue from my question http://stackoverflow.com/questions/33439487/promise-to-string-object-object-or-object-promise/33439488#33439488