### PR TITLE
check exports before amd in case mixed environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This fork has been modified to check `require.js` environments before `AMD`.
+This makes it more reliable in cases where `AMD` is being used in `Node`.
+
 # ES6-Promise (subset of [rsvp.js](https://github.com/tildeio/rsvp.js))
 
 This is a polyfill of the [ES6 Promise](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-constructor). The implementation is a subset of [rsvp.js](https://github.com/tildeio/rsvp.js), if you're wanting extra features and more debugging options, check out the [full library](https://github.com/tildeio/rsvp.js).

--- a/dist/es6-promise.js
+++ b/dist/es6-promise.js
@@ -954,10 +954,10 @@
     };
 
     /* global define:true module:true window: true */
-    if (typeof define === 'function' && define['amd']) {
-      define(function() { return lib$es6$promise$umd$$ES6Promise; });
-    } else if (typeof module !== 'undefined' && module['exports']) {
+    if (typeof module !== 'undefined' && module['exports']) {
       module['exports'] = lib$es6$promise$umd$$ES6Promise;
+    } else if (typeof define === 'function' && define['amd']) {
+      define(function() { return lib$es6$promise$umd$$ES6Promise; });
     } else if (typeof this !== 'undefined') {
       this['ES6Promise'] = lib$es6$promise$umd$$ES6Promise;
     }

--- a/lib/es6-promise.umd.js
+++ b/lib/es6-promise.umd.js
@@ -7,10 +7,10 @@ var ES6Promise = {
 };
 
 /* global define:true module:true window: true */
-if (typeof define === 'function' && define['amd']) {
-  define(function() { return ES6Promise; });
-} else if (typeof module !== 'undefined' && module['exports']) {
+if (typeof module !== 'undefined' && module['exports']) {
   module['exports'] = ES6Promise;
+} else if (typeof define === 'function' && define['amd']) {
+  define(function() { return ES6Promise; });
 } else if (typeof this !== 'undefined') {
   this['ES6Promise'] = ES6Promise;
 }


### PR DESCRIPTION
I am using AMD inside of Node (not a fan of require). Unfortunately, simply requiring the mongodb module broke my app because the mongodb library tries to include the es6-promise library using require but es6-promise checks define() && AMD first.

By checking exports first (and AMD second) I make sure that the library works in mixed AMD/Require environments more reliably.

Now, I know I have broken the ability to use AMD to include the library when in a mixed environment (since it's checking exports first now, which is arguably just the opposite of the problem that currently exists), but given that every library in node uses require, the situation I'm facing will happen 9 out of 10 times, which is that some 3rd party is using require to load it and it's instead trying to use define();

So, while there is no 100% solution for making it automagically determine the environment when the environment is mixed, require is more popular and so checking that first will mean the it works in the majority of cases.

Thoughts?