### PR TITLE
Update README.md with details about PhantomJS requirement for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Notice that we don't assign the result of `polyfill()` to any variable. The `pol
 
 ## Building & Testing
 
+You will need to have PhantomJS installed globally in order to run the tests.
+
+`npm install -g phantomjs`
+
 * `npm run build` to build
 * `npm test` to run tests
-* `npm start` to run a build watcher, and webserver to test 
+* `npm start` to run a build watcher, and webserver to test
 * `npm run test:server` for a testem test runner and watching builder


### PR DESCRIPTION
This PR updates the `README.md` with details about PhantomJS requirement for running tests.

Not having PhantomJS installed under newer node versions, was the cause of #160 reported by me yesterday, once installed, all was well.